### PR TITLE
Add support to custom api name to load on init

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,9 @@ var googleAuth = (function () {
     })
   }
 
-  function initClient(config) {
+  function initClient(config, apiName) {
     return new Promise((resolve) => {
-      window.gapi.load('auth2', () => {
+      window.gapi.load(apiName, () => {
         window.gapi.auth2.init(config)
           .then(() => {
             resolve(window.gapi)
@@ -42,10 +42,10 @@ var googleAuth = (function () {
       return !!this.GoogleAuth
     };
 
-    this.load = (config, prompt) => {
+    this.load = (config, prompt, apiName) => {
       installClient()
         .then(() => {
-          return initClient(config)
+          return initClient(config, apiName)
         })
         .then((gapi) => {
           this.GoogleAuth = gapi.auth2.getAuthInstance()
@@ -121,7 +121,7 @@ var googleAuth = (function () {
 
 
 
-function installGoogleAuthPlugin(Vue, options) {
+function installGoogleAuthPlugin(Vue, options, apiNameToLoad) {
   /* eslint-disable */
   //set config
   let GoogleAuthConfig = null
@@ -137,6 +137,7 @@ function installGoogleAuthPlugin(Vue, options) {
   } else {
     console.warn('invalid option type. Object type accepted only')
   }
+  const apiName = apiNameToLoad ? apiNameToLoad : 'client'  
 
   //Install Vue plugin
   Vue.gAuth = googleAuth
@@ -147,7 +148,7 @@ function installGoogleAuthPlugin(Vue, options) {
       }
     }
   })
-  Vue.gAuth.load(GoogleAuthConfig, prompt)
+  Vue.gAuth.load(GoogleAuthConfig, prompt, apiName)
 }
 
 export default installGoogleAuthPlugin

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ function installGoogleAuthPlugin(Vue, options, apiNameToLoad) {
   } else {
     console.warn('invalid option type. Object type accepted only')
   }
-  const apiName = apiNameToLoad ? apiNameToLoad : 'client'  
+  const apiName = apiNameToLoad ? apiNameToLoad : 'auth2'  
 
   //Install Vue plugin
   Vue.gAuth = googleAuth

--- a/index.ts
+++ b/index.ts
@@ -163,7 +163,7 @@ function installGoogleAuthPlugin(Vue: typeof _Vue, options?: any, apiNameToLoad?
     // tslint:disable-next-line
     console.warn('invalid option type. Object type accepted only');
   }
-  const apiName = apiNameToLoad ? apiNameToLoad : 'client'  
+  const apiName = apiNameToLoad ? apiNameToLoad : 'auth2'  
 
   // Install Vue plugin
   Object.defineProperties(Vue.prototype, {

--- a/index.ts
+++ b/index.ts
@@ -22,9 +22,9 @@ const googleAuth = ((): any => {
     });
   };
 
-  const initClient = (config: any) => {
+  const initClient = (config: any, apiName: string) => {
     return new Promise((resolve) => {
-      window.gapi.load('auth2', () => {
+      window.gapi.load(apiName, () => {
         window.gapi.auth2.init(config)
           .then(() => {
             resolve(window.gapi);
@@ -44,10 +44,10 @@ const googleAuth = ((): any => {
       return !!this.GoogleAuth;
     };
 
-    this.load = (config: any, prompt: string) => {
+    this.load = (config: any, prompt: string, apiName: string) => {
       installClient()
         .then(() => {
-          return initClient(config);
+          return initClient(config, apiName);
         })
         .then((gapi: any) => {
           this.GoogleAuth = gapi.auth2.getAuthInstance();
@@ -139,7 +139,7 @@ const googleAuth = ((): any => {
 })();
 
 
-function installGoogleAuthPlugin(Vue: typeof _Vue, options?: any): void {
+function installGoogleAuthPlugin(Vue: typeof _Vue, options?: any, apiNameToLoad?: string): void {
   // set config
   let GoogleAuthConfig = null;
   const GoogleAuthDefaultConfig = {
@@ -163,6 +163,7 @@ function installGoogleAuthPlugin(Vue: typeof _Vue, options?: any): void {
     // tslint:disable-next-line
     console.warn('invalid option type. Object type accepted only');
   }
+  const apiName = apiNameToLoad ? apiNameToLoad : 'client'  
 
   // Install Vue plugin
   Object.defineProperties(Vue.prototype, {
@@ -172,7 +173,7 @@ function installGoogleAuthPlugin(Vue: typeof _Vue, options?: any): void {
       },
     },
   });
-  googleAuth.load(GoogleAuthConfig, prompt);
+  googleAuth.load(GoogleAuthConfig, prompt, apiName);
 }
 // tslint:disable-next-line
 export default installGoogleAuthPlugin;


### PR DESCRIPTION
Hi!
First of all, thanks for the amazing work done in this lib!

**Current scenario:**
Currently, the initial load of the Google API is called **window.gapi.load("auth2", fn)**

**The problem:**
Would be nice to be able to customize or add others google APIs on load. So, this lib would be more richer,  enabling anyone who use it to extend it beyond the signIn and signOut.
In my case, i would need to load like this: **window.gapi.load("client:auth2", fn)**

**The solution:**
Add a parameter on **installGoogleAuthPlugin** with default value as "auth2" to be able to load libs other than auth2.