### PR TITLE
GoogleAuthDefaultConfig discoveryDocs option should be removed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ function installGoogleAuthPlugin(Vue, options) {
   /* eslint-disable */
   //set config
   let GoogleAuthConfig = null
-  let GoogleAuthDefaultConfig = { scope: 'profile email', discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'] }
+  let GoogleAuthDefaultConfig = { scope: 'profile email' }
   let prompt = 'select_account'
   if (typeof options === 'object') {
     GoogleAuthConfig = Object.assign(GoogleAuthDefaultConfig, options)

--- a/index.ts
+++ b/index.ts
@@ -148,7 +148,6 @@ function installGoogleAuthPlugin(Vue: typeof _Vue, options?: any): void {
   let GoogleAuthConfig: any = null;
   const GoogleAuthDefaultConfig = {
     scope: 'profile email',
-    discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'],
   };
   let prompt = 'select_account';
   if (typeof options === 'object') {


### PR DESCRIPTION
The parameter discoveryDocs described in GoogleAuthDefaultConfig should be removed because it is not available in [gapi.auth2.ClientConfig](https://developers.google.com/identity/sign-in/web/reference#gapiauth2clientconfig). This can be confusing in future update or modification.

In addition, we don't use drive api in OAuth2 sign in.

Thank you for nice library, anyway.