### PR TITLE
For vue3 changes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ Vue.use(GAuth, gauthOption)
 ```
 Please Don't use `plus.login` scope. [It will be deprecated.](https://developers.google.com/identity/sign-in/web/quick-migration-guide)
 
+### Initialization for VUE3
+```javascript
+//src/main.js
+import GAuth from 'vue-google-oauth2'
+
+// set auth config
+const prompt = 'select_account'
+const GoogleAuthConfig = Object.assign({ scope: 'profile email' }, {
+  clientId: CLIENT_ID',
+  scope: 'profile email https://www.googleapis.com/auth/plus.login',
+});
+
+
+// Install Vue plugin
+app.config.globalProperties.$gAuth = googleAuth;
+app.config.globalProperties.$gAuth.load(GoogleAuthConfig, prompt)
+
+```
+
 ### Initialization for Nuxt
 1. creates plug-in file for nuxt
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,4 @@
-
 var googleAuth = (function () {
-
   function installClient() {
     var apiUrl = 'https://apis.google.com/js/api.js'
     return new Promise((resolve) => {
@@ -122,36 +120,4 @@ var googleAuth = (function () {
   return new Auth()
 })();
 
-
-
-
-function installGoogleAuthPlugin(Vue, options) {
-  /* eslint-disable */
-  //set config
-  let GoogleAuthConfig = null
-  let GoogleAuthDefaultConfig = { scope: 'profile email' }
-  let prompt = 'select_account'
-  if (typeof options === 'object') {
-    GoogleAuthConfig = Object.assign(GoogleAuthDefaultConfig, options)
-    if (options.scope) GoogleAuthConfig.scope = options.scope
-    if (options.prompt) prompt = options.prompt
-    if (!options.clientId) {
-      console.warn('clientId is required')
-    }
-  } else {
-    console.warn('invalid option type. Object type accepted only')
-  }
-
-  //Install Vue plugin
-  Vue.gAuth = googleAuth
-  Object.defineProperties(Vue.prototype, {
-    $gAuth: {
-      get: function () {
-        return Vue.gAuth
-      }
-    }
-  })
-  Vue.gAuth.load(GoogleAuthConfig, prompt)
-}
-
-export default installGoogleAuthPlugin
+export default googleAuth;


### PR DESCRIPTION

The method of registering $gAuth in vue3 has been changed, and an error occurs if you use it as before.

```
index.js?c9bf:147 Uncaught TypeError: Object.defineProperties called on non-object
    at Function.defineProperties (<anonymous>)
    at installGoogleAuthPlugin (index.js?c9bf:147)
    at Object.use (runtime-core.esm-bundler.js?5c40:2949)
    at eval (main.js?911e:17)
    at Module../frontend/src/main.js (index.js:1055)
    at __webpack_require__ (index.js:854)
    at fn (index.js:151)
    at Object.1 (index.js:1151)
    at __webpack_require__ (index.js:854)
    at checkDeferredModules (index.js:46)
```

Therefore, it is being used by modifying it as follows. (changed) 
 I create a separate branch and share it to help others.

