### PR TITLE
Add void return type to installClient

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@ const googleAuth = ((): any => {
 
   const installClient = () => {
     const apiUrl = 'https://apis.google.com/js/api.js';
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       const script: any = document.createElement('script');
       script.src = apiUrl;
       script.onreadystatechange = script.onload = () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-google-oauth2",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Handling Google Auth2 sign-in and sign-out",
   "main": "index.js",
   "types": "index.ts",


### PR DESCRIPTION
Fixes TypeScript error TS2794 that occurs on line 17:

`TS2794: Expected 1 arguments, but got 0. Did you forget to include 'void' in your type argument to 'Promise'?`